### PR TITLE
Update Mercedes-Benz S-Class generations: Add complete generation data with Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Mercedes-Benz S-Class
 
+This repository contains signal set configurations for the Mercedes-Benz S-Class, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Mercedes-Benz S-Class.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,38 @@
+references:
+  - "https://en.wikipedia.org/wiki/Mercedes-Benz_S-Class"
+
+generations:
+  - name: "W116 (First Generation)"
+    start_year: 1972
+    end_year: 1980
+    description: "First generation officially branded as S-Class, introduced with the W116 chassis code in 1972."
+
+  - name: "W126 (Second Generation)"
+    start_year: 1979
+    end_year: 1991
+    description: "Second generation S-Class, premiered in September 1979, launched in March 1980, featuring improved aerodynamics and enlarged aluminum engine blocks."
+
+  - name: "W140 (Third Generation)"
+    start_year: 1991
+    end_year: 1998
+    description: "Third generation introduced in 1991, featuring two wheelbase lengths and a shorter-wheelbase W140 coupé."
+
+  - name: "W220 (Fourth Generation)"
+    start_year: 1998
+    end_year: 2005
+    description: "Fourth generation presented in July 1998, marketed as a sedan only, despite being smaller than the previous generation, offered more interior space."
+
+  - name: "W221 (Fifth Generation)"
+    start_year: 2005
+    end_year: 2013
+    description: "Fifth generation introduced in autumn 2005 at the Frankfurt International Motor Show, featuring a big change in design with newly developed engines."
+
+  - name: "W222 (Sixth Generation)"
+    start_year: 2013
+    end_year: 2020
+    description: "Sixth generation produced from June 2013 to September 2020 for the W222 sedan, with C217 coupé and A217 cabriolet variants produced from November 2014 to August 2020."
+
+  - name: "W223 (Seventh Generation)"
+    start_year: 2021
+    end_year: null
+    description: "Seventh generation introduced in 2021, continuing production through the present."


### PR DESCRIPTION
- Created generations.yaml with 7 generations from W116 (1972-1980) through W223 (2021-present)
- Added Wikipedia reference for official generation definitions and production dates
- Updated README.md with standard template documentation
- Each generation includes proper start/end years and descriptive information from Wikipedia

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
