### PR TITLE
Update Mercedes-Benz S-Class generations: corrected W223 start year

### DIFF
--- a/generations.yaml
+++ b/generations.yaml
@@ -33,6 +33,6 @@ generations:
     description: "Sixth generation produced from June 2013 to September 2020 for the W222 sedan, with C217 coupé and A217 cabriolet variants produced from November 2014 to August 2020."
 
   - name: "W223 (Seventh Generation)"
-    start_year: 2021
+    start_year: 2020
     end_year: null
-    description: "Seventh generation introduced in 2021, continuing production through the present."
+    description: "Seventh generation unveiled on September 2, 2020, continuing production through the present."


### PR DESCRIPTION
- Changed W223 (Seventh Generation) start_year from 2021 to 2020
- Wikipedia confirms the W223 was unveiled on September 2, 2020
- All other generation dates verified against Wikipedia article
